### PR TITLE
Fix bug when grid shows entries with multiple stock IDs but same item ID

### DIFF
--- a/code/app/code/community/Rofra/Salesorderitemgrid/Block/Adminhtml/Order/Items/Grid.php
+++ b/code/app/code/community/Rofra/Salesorderitemgrid/Block/Adminhtml/Order/Items/Grid.php
@@ -26,7 +26,6 @@ class Rofra_Salesorderitemgrid_Block_Adminhtml_Order_Items_Grid extends Mage_Adm
     {
         $collection = Mage::getModel('sales/order_item')->getCollection();
         $collection->join(array('og' =>'sales/order_grid'), 'main_table.order_id = og.entity_id', array('billing_name', 'shipping_name', 'increment_id', 'status', 'og_created_at' =>'og.created_at') );
-        $collection->join(array('si' => 'cataloginventory/stock_item'), 'main_table.product_id = si.product_id', array('si_qty' => 'si.qty'));
 
         // One line per entry (configurable / simple management)
         $collection->addAttributeToFilter('parent_item_id', array('is' => new Zend_Db_Expr('null')));


### PR DESCRIPTION
- Before, order items would break if the grid shows an item with multiple stock IDs but have the same item ID
- Join is not needed to show information on the order items page

![image](https://user-images.githubusercontent.com/16995169/32246110-4de10610-be54-11e7-839b-1ffc50ba7337.png)
